### PR TITLE
Support Discord CDN as a host and a few other fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.14.8
 
 # Mod Properties
-	mod_version = 1.4.1
+	mod_version = 1.4.2
 	maven_group = eu.midnightdust
 	archives_base_name = picturesign
 

--- a/src/main/java/eu/midnightdust/picturesign/render/PictureSignRenderer.java
+++ b/src/main/java/eu/midnightdust/picturesign/render/PictureSignRenderer.java
@@ -26,7 +26,7 @@ public class PictureSignRenderer {
         }
         if (!url.contains(".png") && !url.contains(".jpg") && !url.contains(".jpeg")) return;
         if (PictureSignConfig.safeMode && !url.startsWith("https://i.imgur.com/") && !url.startsWith("https://i.ibb.co/")
-                && !url.startsWith("https://pictshare.net/") && !url.startsWith("https://iili.io/"))
+                && !url.startsWith("https://pictshare.net/") && !url.startsWith("https://iili.io/") && !url.startsWith("https://cdn.discordapp.com/") && !url.startsWith("https://media.discordapp.net/"))
             return;
         World world = signBlockEntity.getWorld();
         BlockPos pos = signBlockEntity.getPos();

--- a/src/main/java/eu/midnightdust/picturesign/render/PictureSignRenderer.java
+++ b/src/main/java/eu/midnightdust/picturesign/render/PictureSignRenderer.java
@@ -26,7 +26,8 @@ public class PictureSignRenderer {
         }
         if (!url.contains(".png") && !url.contains(".jpg") && !url.contains(".jpeg")) return;
         if (PictureSignConfig.safeMode && !url.startsWith("https://i.imgur.com/") && !url.startsWith("https://i.ibb.co/")
-                && !url.startsWith("https://pictshare.net/") && !url.startsWith("https://iili.io/") && !url.startsWith("https://cdn.discordapp.com/") && !url.startsWith("https://media.discordapp.net/"))
+                && !url.startsWith("https://pictshare.net/") && !url.startsWith("https://iili.io/")
+                && !url.startsWith("https://cdn.discordapp.com/") && !url.startsWith("https://media.discordapp.net/"))
             return;
         World world = signBlockEntity.getWorld();
         BlockPos pos = signBlockEntity.getPos();

--- a/src/main/java/eu/midnightdust/picturesign/screen/PictureSignHelperScreen.java
+++ b/src/main/java/eu/midnightdust/picturesign/screen/PictureSignHelperScreen.java
@@ -100,7 +100,7 @@ public class PictureSignHelperScreen extends Screen {
             String[] dimensions = new String[5];
             for (int i = 0; i < dimensions.length; ++i){
                 if (sign.getTextOnRow(3, false).getString().split(":").length > i)
-                dimensions[i] = sign.getTextOnRow(3, false).getString().split(":")[i];
+                    dimensions[i] = sign.getTextOnRow(3, false).getString().split(":")[i];
             }
             dimensions[0] = s;
             StringBuilder mergedDimensions = new StringBuilder();
@@ -111,7 +111,7 @@ public class PictureSignHelperScreen extends Screen {
             }
             sign.setTextOnRow(3, Text.of(String.valueOf(mergedDimensions)));
             text = IntStream.range(0, 4).mapToObj((row) ->
-            sign.getTextOnRow(row, false)).map(Text::getString).toArray(String[]::new);
+                    sign.getTextOnRow(row, false)).map(Text::getString).toArray(String[]::new);
         });
         widthWidget.setText(initialDimensions[0]);
         this.addDrawableChild(widthWidget);

--- a/src/main/java/eu/midnightdust/picturesign/screen/PictureSignHelperScreen.java
+++ b/src/main/java/eu/midnightdust/picturesign/screen/PictureSignHelperScreen.java
@@ -82,8 +82,7 @@ public class PictureSignHelperScreen extends Screen {
             Objects.requireNonNull(client).setScreen(new SignEditScreen(this.sign,false));
         }, Text.of("")));
         TextFieldWidget linkWidget = new TextFieldWidget(textRenderer,this.width / 2 - 175,this.height / 5 + 13,210,40, Text.of("url"));
-        linkWidget.setMaxLength(90);
-        linkWidget.setText(PictureURLUtils.getLink(sign));
+        linkWidget.setMaxLength(2048);
         linkWidget.setChangedListener(s -> {
             String[] lines = breakLink(PictureURLUtils.shortenLink(s));
             sign.setTextOnRow(0, Text.of(lines[0]));
@@ -93,15 +92,15 @@ public class PictureSignHelperScreen extends Screen {
             text = IntStream.range(0, 4).mapToObj((row) ->
                     sign.getTextOnRow(row, false)).map(Text::getString).toArray(String[]::new);
         });
+        linkWidget.setText(PictureURLUtils.getLink(sign));
         this.addDrawableChild(linkWidget);
         String[] initialDimensions = sign.getTextOnRow(3, false).getString().split(":");
         TextFieldWidget widthWidget = new TextFieldWidget(textRenderer,this.width / 2 - 175,this.height / 5 + 70,30,20, Text.of("width"));
-        widthWidget.setText(initialDimensions[0]);
         widthWidget.setChangedListener(s -> {
             String[] dimensions = new String[5];
             for (int i = 0; i < dimensions.length; ++i){
                 if (sign.getTextOnRow(3, false).getString().split(":").length > i)
-                    dimensions[i] = sign.getTextOnRow(3, false).getString().split(":")[i];
+                dimensions[i] = sign.getTextOnRow(3, false).getString().split(":")[i];
             }
             dimensions[0] = s;
             StringBuilder mergedDimensions = new StringBuilder();
@@ -112,11 +111,11 @@ public class PictureSignHelperScreen extends Screen {
             }
             sign.setTextOnRow(3, Text.of(String.valueOf(mergedDimensions)));
             text = IntStream.range(0, 4).mapToObj((row) ->
-                    sign.getTextOnRow(row, false)).map(Text::getString).toArray(String[]::new);
+            sign.getTextOnRow(row, false)).map(Text::getString).toArray(String[]::new);
         });
+        widthWidget.setText(initialDimensions[0]);
         this.addDrawableChild(widthWidget);
         TextFieldWidget heightWidget = new TextFieldWidget(textRenderer,this.width / 2 - 140,this.height / 5 + 70,30,20, Text.of("height"));
-        heightWidget.setText(initialDimensions[1]);
         heightWidget.setChangedListener(s -> {
             String[] dimensions = new String[5];
             for (int i = 0; i < dimensions.length; ++i){
@@ -134,9 +133,9 @@ public class PictureSignHelperScreen extends Screen {
             text = IntStream.range(0, 4).mapToObj((row) ->
                     sign.getTextOnRow(row, false)).map(Text::getString).toArray(String[]::new);
         });
+        heightWidget.setText(initialDimensions[1]);
         this.addDrawableChild(heightWidget);
         TextFieldWidget posXWidget = new TextFieldWidget(textRenderer,this.width / 2 - 105,this.height / 5 + 70,30,20, Text.of("posX"));
-        posXWidget.setText(initialDimensions[2]);
         posXWidget.setChangedListener(s -> {
             String[] dimensions = new String[5];
             for (int i = 0; i < dimensions.length; ++i){
@@ -154,9 +153,9 @@ public class PictureSignHelperScreen extends Screen {
             text = IntStream.range(0, 4).mapToObj((row) ->
                     sign.getTextOnRow(row, false)).map(Text::getString).toArray(String[]::new);
         });
+        posXWidget.setText(initialDimensions[2]);
         this.addDrawableChild(posXWidget);
         TextFieldWidget posYWidget = new TextFieldWidget(textRenderer,this.width / 2 - 70,this.height / 5 + 70,30,20, Text.of("posY"));
-        posYWidget.setText(initialDimensions[3]);
         posYWidget.setChangedListener(s -> {
             String[] dimensions = new String[5];
             for (int i = 0; i < dimensions.length; ++i){
@@ -174,9 +173,9 @@ public class PictureSignHelperScreen extends Screen {
             text = IntStream.range(0, 4).mapToObj((row) ->
                     sign.getTextOnRow(row, false)).map(Text::getString).toArray(String[]::new);
         });
+        posYWidget.setText(initialDimensions[3]);
         this.addDrawableChild(posYWidget);
         TextFieldWidget posZWidget = new TextFieldWidget(textRenderer,this.width / 2 - 35,this.height / 5 + 70,30,20, Text.of("posZ"));
-        posZWidget.setText(initialDimensions[4]);
         posZWidget.setChangedListener(s -> {
             String[] dimensions = new String[5];
             for (int i = 0; i < dimensions.length; ++i){
@@ -194,6 +193,7 @@ public class PictureSignHelperScreen extends Screen {
             text = IntStream.range(0, 4).mapToObj((row) ->
                     sign.getTextOnRow(row, false)).map(Text::getString).toArray(String[]::new);
         });
+        posZWidget.setText(initialDimensions[4]);
         this.addDrawableChild(posZWidget);
         this.model = SignBlockEntityRenderer.createSignModel(this.client.getEntityModelLoader(), SignBlockEntityRenderer.getSignType(sign.getCachedState().getBlock()));
     }
@@ -250,7 +250,7 @@ public class PictureSignHelperScreen extends Screen {
     public void render(MatrixStack matrices, int mouseX, int mouseY, float delta) {
         DiffuseLighting.disableGuiDepthLighting();
         this.renderBackground(matrices);
-        drawTextWithShadow(matrices,textRenderer, Text.of("Link" + (PictureSignConfig.safeMode ? " (imgur.com/imgbb.com/iili.io/pictshare.net)" : "")),this.width / 2 - 175, this.height / 5 + 3, -8816268);
+        drawTextWithShadow(matrices,textRenderer, Text.of("Link" + (PictureSignConfig.safeMode ? " (imgur.com/imgbb.com/iili.io/pictshare.net/cdn.discordapp.com/media.discordapp.net)" : "")),this.width / 2 - 175, this.height / 5 + 3, -8816268);
         drawTextWithShadow(matrices,textRenderer, Text.of("Width"),this.width / 2 - 175, this.height / 5 + 60, -8816268);
         drawTextWithShadow(matrices,textRenderer, Text.of("Height"),this.width / 2 - 140, this.height / 5 + 60, -8816268);
         drawTextWithShadow(matrices,textRenderer, Text.of("PosX"),this.width / 2 - 105, this.height / 5 + 60, -8816268);

--- a/src/main/java/eu/midnightdust/picturesign/util/PictureURLUtils.java
+++ b/src/main/java/eu/midnightdust/picturesign/util/PictureURLUtils.java
@@ -12,16 +12,18 @@ public class PictureURLUtils {
         if (url.startsWith("imgur:")) url = url.replace("imgur:", "https://i.imgur.com/");
         if (url.startsWith("imgbb:")) url = url.replace("imgbb:", "https://i.ibb.co/");
         if (url.startsWith("iili:")) url = url.replace("iili:", "https://iili.io/");
+        if (url.startsWith("discord:")) url = url.replace("discord:", "https://cdn.discordapp.com/attachments/");
         return url;
     }
     public static String shortenLink(String url) {
-        if (url.contains("pictshare.net/")) url = url.replace("pictshare.net/", "ps:");
-        if (url.contains("i.imgur.com/")) url = url.replace("i.imgur.com/", "imgur:");
-        if (url.contains("i.ibb.co/:")) url = url.replace("i.ibb.co/", "imgbb:");
-        if (url.contains("iili.io/")) url = url.replace("iili.io/", "iili:");
         if (url.startsWith("https://")) {
             url = url.replace("https://", "");
         }
+        if (url.startsWith("pictshare.net/")) url = url.replaceFirst("\\Qpictshare.net/\\E", "ps:");
+        if (url.startsWith("i.imgur.com/")) url = url.replaceFirst("\\Qi.imgur.com/\\E", "imgur:");
+        if (url.startsWith("i.ibb.co/:")) url = url.replaceFirst("\\Qi.ibb.co/\\E", "imgbb:");
+        if (url.startsWith("iili.io/")) url = url.replaceFirst("\\Qiili.io/\\E", "iili:");
+        if (url.startsWith("discord:")) url = url.replaceFirst("\\Qiili.io/\\E", "discord:");
         return url;
     }
 }

--- a/src/main/java/eu/midnightdust/picturesign/util/PictureURLUtils.java
+++ b/src/main/java/eu/midnightdust/picturesign/util/PictureURLUtils.java
@@ -23,7 +23,7 @@ public class PictureURLUtils {
         if (url.startsWith("i.imgur.com/")) url = url.replaceFirst("\\Qi.imgur.com/\\E", "imgur:");
         if (url.startsWith("i.ibb.co/:")) url = url.replaceFirst("\\Qi.ibb.co/\\E", "imgbb:");
         if (url.startsWith("iili.io/")) url = url.replaceFirst("\\Qiili.io/\\E", "iili:");
-        if (url.startsWith("discord:")) url = url.replaceFirst("\\Qiili.io/\\E", "discord:");
+        if (url.startsWith("cdn.discordapp.com/attachments/")) url = url.replaceFirst("\\Qcdn.discordapp.com/attachments/\\E", "discord:");
         return url;
     }
 }


### PR DESCRIPTION
Discord CDN has been added as a safe host
- Also includes Discord's resize cache server
- Patched the max URL length to be 2048 as Discord CDN URLs are often over 90 characters

Fix URL shortener replacement by only replacing the first instance of the shortened URL and only if it is the start of the URL
The helper GUI will write the position and scaling metadata on load now by setting the default text after the change listener is registered